### PR TITLE
2830882 Add offcanvas as own Dialog

### DIFF
--- a/core/misc/dialog/dialog.ajax.js
+++ b/core/misc/dialog/dialog.ajax.js
@@ -143,7 +143,9 @@
 
     // Open the dialog itself.
     response.dialogOptions = response.dialogOptions || {};
-    var dialog = Drupal.dialog($dialog.get(0), response.dialogOptions);
+    var dialogObject = Drupal.dialog.getDialogRenderer(response.dialogOptions);
+    var dialog = dialogObject($dialog.get(0), response.dialogOptions);
+
     if (response.dialogOptions.modal) {
       dialog.showModal();
     }

--- a/core/misc/dialog/dialog.js
+++ b/core/misc/dialog/dialog.js
@@ -79,7 +79,7 @@
 
     function openDialog(settings) {
       settings = $.extend({}, drupalSettings.dialog, options, settings);
-      $element.attr('data-dialog-render', 'dialog');
+      $element.attr('data-dialog-renderer', 'dialog');
       // Trigger a global event to allow scripts to bind events to the dialog.
       $(window).trigger('dialog:beforecreate', [dialog, $element, settings]);
       $element.dialog(settings);
@@ -99,8 +99,8 @@
   };
 
   Drupal.dialog.getDialogRenderer = function (options) {
-    if (options.hasOwnProperty('drupalDialogType') && Drupal.hasOwnProperty(options.drupalDialogType)) {
-      return Drupal[options.drupalDialogType];
+    if (options.hasOwnProperty('drupalDialogRenderer') && Drupal.hasOwnProperty(options.drupalDialogRenderer)) {
+      return Drupal[options.drupalDialogRenderer];
     }
     else {
       return Drupal.dialog;
@@ -108,8 +108,8 @@
   };
 
   Drupal.dialog.getDialogRendererFromEvent = function (event) {
-    if ($(event.target).attr('data-dialog-render')) {
-      return Drupal[$(event.target).attr('data-dialog-render')];
+    if ($(event.target).attr('data-dialog-renderer')) {
+      return Drupal[$(event.target).attr('data-dialog-renderer')];
     }
     return Drupal.dialog;
 

--- a/core/misc/dialog/dialog.js
+++ b/core/misc/dialog/dialog.js
@@ -31,7 +31,7 @@
     // `jQuery(event.target).remove()` as well, to remove the dialog on
     // closing.
     close: function (event) {
-      Drupal.dialog(event.target).close();
+      Drupal.dialog.getDialogRendererFromEvent(event)(event.target).close();
       Drupal.detachBehaviors(event.target, null, 'unload');
     }
   };
@@ -79,6 +79,7 @@
 
     function openDialog(settings) {
       settings = $.extend({}, drupalSettings.dialog, options, settings);
+      $element.attr('data-dialog-render', 'dialog');
       // Trigger a global event to allow scripts to bind events to the dialog.
       $(window).trigger('dialog:beforecreate', [dialog, $element, settings]);
       $element.dialog(settings);
@@ -95,6 +96,23 @@
     }
 
     return dialog;
+  };
+
+  Drupal.dialog.getDialogRenderer = function (options) {
+    if (options.hasOwnProperty('drupalDialogType') && Drupal.hasOwnProperty(options.drupalDialogType)) {
+      return Drupal[options.drupalDialogType];
+    }
+    else {
+      return Drupal.dialog;
+    }
+  };
+
+  Drupal.dialog.getDialogRendererFromEvent = function (event) {
+    if ($(event.target).attr('data-dialog-render')) {
+      return Drupal[$(event.target).attr('data-dialog-render')];
+    }
+    return Drupal.dialog;
+
   };
 
 })(jQuery, Drupal, drupalSettings);

--- a/core/modules/outside_in/js/off-canvas.js
+++ b/core/modules/outside_in/js/off-canvas.js
@@ -1,160 +1,190 @@
 /**
  * @file
- * Drupal's off-canvas library.
+ * Dialog API inspired by HTML5 dialog element.
  *
- * @todo This functionality should extracted into a new core library or a part
- *  of the current drupal.dialog.ajax library.
- *  https://www.drupal.org/node/2784443
+ * @see http://www.whatwg.org/specs/web-apps/current-work/multipage/commands.html#the-dialog-element
  */
 
-(function ($, Drupal, debounce, displace) {
+(function ($, Drupal, drupalSettings, debounce, displace) {
 
   'use strict';
 
-  // The minimum width to use body displace needs to match the width at which
-  // the tray will be %100 width. @see outside_in.module.css
-  var minDisplaceWidth = 768;
-
   /**
-   * The edge of the screen that the dialog should appear on.
+   * Polyfill HTML5 dialog element with jQueryUI.
    *
-   * @type {string}
-   */
-  var edge = document.documentElement.dir === 'rtl' ? 'left' : 'right';
-
-  var $mainCanvasWrapper = $('[data-off-canvas-main-canvas]');
-
-  /**
-   * Resets the size of the dialog.
+   * @param {HTMLElement} element
+   *   The element that holds the dialog.
+   * @param {object} options
+   *   jQuery UI options to be passed to the dialog.
    *
-   * @param {jQuery.Event} event
-   *   The event triggered.
+   * @return {Drupal.dialog~dialogDefinition}
+   *   The dialog instance.
    */
-  function resetSize(event) {
-    var offsets = displace.offsets;
-    var $element = event.data.$element;
-    var $widget = $element.dialog('widget');
+  Drupal.offCanvasDialog = function (element, options) {
+    var undef;
+    var $element = $(element);
 
-    var adjustedOptions = {
-      // @see http://api.jqueryui.com/position/
-      position: {
-        my: edge + ' top',
-        at: edge + ' top' + (offsets.top !== 0 ? '+' + offsets.top : ''),
-        of: window
-      }
+    // The minimum width to use body displace needs to match the width at which
+    // the tray will be %100 width. @see outside_in.module.css
+    var minDisplaceWidth = 768;
+
+    /**
+     * The edge of the screen that the dialog should appear on.
+     *
+     * @type {string}
+     */
+    var edge = document.documentElement.dir === 'rtl' ? 'left' : 'right';
+
+    var $mainCanvasWrapper = $('[data-off-canvas-main-canvas]');
+    var dialog = {
+      open: false,
+      returnValue: undef,
+      show: function () {
+        openDialog({modal: false});
+      },
+      showModal: function () {
+        openDialog({modal: true});
+      },
+      close: closeDialog
     };
 
-    $widget.css({
-      position: 'fixed',
-      height: ($(window).height() - (offsets.top + offsets.bottom)) + 'px'
-    });
-
-    $element
-      .dialog('option', adjustedOptions)
-      .trigger('dialogContentResize.off-canvas');
-  }
-
-  /**
-   * Adjusts the dialog on resize.
-   *
-   * @param {jQuery.Event} event
-   *   The event triggered.
-   */
-  function handleDialogResize(event) {
-    var $element = event.data.$element;
-    var $widget = $element.dialog('widget');
-
-    var $offsets = $widget.find('> :not(#drupal-off-canvas, .ui-resizable-handle)');
-    var offset = 0;
-    var modalHeight;
-
-    // Let scroll element take all the height available.
-    $element.css({height: 'auto'});
-    modalHeight = $widget.height();
-    $offsets.each(function () { offset += $(this).outerHeight(); });
-
-    // Take internal padding into account.
-    var scrollOffset = $element.outerHeight() - $element.height();
-    $element.height(modalHeight - offset - scrollOffset);
-  }
-
-  /**
-   * Adjusts the body padding when the dialog is resized.
-   *
-   * @param {jQuery.Event} event
-   *   The event triggered.
-   */
-  function bodyPadding(event) {
-    if ($('body').outerWidth() < minDisplaceWidth) {
-      return;
+    function beforeCreate(settings) {
+      $('body').addClass('js-tray-open');
+      // @see http://api.jqueryui.com/position/
+      settings.position = {
+        my: 'left top',
+        at: edge + ' top',
+        of: window
+      };
+      settings.dialogClass += ' ui-dialog-off-canvas';
+      // Applies initial height to dialog based on window height.
+      // See http://api.jqueryui.com/dialog for all dialog options.
+      settings.height = $(window).height();
+      $element.attr('data-dialog-render', 'offCanvasDialog');
     }
-    var $element = event.data.$element;
-    var $widget = $element.dialog('widget');
 
-    var width = $widget.outerWidth();
-    var mainCanvasPadding = $mainCanvasWrapper.css('padding-' + edge);
-    if (width !== mainCanvasPadding) {
-      $mainCanvasWrapper.css('padding-' + edge, width + 'px');
-      $widget.attr('data-offset-' + edge, width);
-      displace();
+    function afterCreate(settings) {
+      var eventData = {settings: settings, $element: $element};
+      $('.ui-dialog-off-canvas, .ui-dialog-off-canvas .ui-dialog-titlebar').toggleClass('ui-dialog-empty-title', !settings.title);
+
+      $element
+        .on('dialogresize.off-canvas', eventData, debounce(bodyPadding, 100))
+        .on('dialogContentResize.off-canvas', eventData, handleDialogResize)
+        .on('dialogContentResize.off-canvas', eventData, debounce(bodyPadding, 100))
+        .trigger('dialogresize.off-canvas');
+
+      $element.dialog('widget').attr('data-offset-' + edge, '');
+
+      $(window)
+        .on('resize.off-canvas scroll.off-canvas', eventData, debounce(resetSize, 100))
+        .trigger('resize.off-canvas');
     }
-  }
 
-  /**
-   * Attaches off-canvas dialog behaviors.
-   *
-   * @type {Drupal~behavior}
-   *
-   * @prop {Drupal~behaviorAttach} attach
-   *   Attaches event listeners for off-canvas dialogs.
-   */
-  Drupal.behaviors.offCanvasEvents = {
-    attach: function () {
-      $(window).once('off-canvas').on({
-        'dialog:aftercreate': function (event, dialog, $element, settings) {
-          if ($element.is('#drupal-off-canvas')) {
-            var eventData = {settings: settings, $element: $element};
-            $('.ui-dialog-off-canvas, .ui-dialog-off-canvas .ui-dialog-titlebar').toggleClass('ui-dialog-empty-title', !settings.title);
+    function openDialog(settings) {
+      settings = $.extend({}, drupalSettings.dialog, options, settings);
+      // Trigger a global event to allow scripts to bind events to the dialog.
+      $(window).trigger('dialog:beforecreate', [dialog, $element, settings]);
+      beforeCreate(settings);
+      $element.dialog(settings);
+      dialog.open = true;
+      afterCreate(settings);
+      $(window).trigger('dialog:aftercreate', [dialog, $element, settings]);
+    }
 
-            $element
-              .on('dialogresize.off-canvas', eventData, debounce(bodyPadding, 100))
-              .on('dialogContentResize.off-canvas', eventData, handleDialogResize)
-              .on('dialogContentResize.off-canvas', eventData, debounce(bodyPadding, 100))
-              .trigger('dialogresize.off-canvas');
+    function beforeClose() {
+      $('body').removeClass('js-tray-open');
+      // Remove all *.off-canvas events
+      $(document).off('.off-canvas');
+      $(window).off('.off-canvas');
+      $mainCanvasWrapper.css('padding-' + edge, 0);
+    }
 
-            $element.dialog('widget').attr('data-offset-' + edge, '');
+    function closeDialog(value) {
+      beforeClose();
+      $(window).trigger('dialog:beforeclose', [dialog, $element]);
+      $element.dialog('close');
+      dialog.returnValue = value;
+      dialog.open = false;
+      $(window).trigger('dialog:afterclose', [dialog, $element]);
+    }
 
-            $(window)
-              .on('resize.off-canvas scroll.off-canvas', eventData, debounce(resetSize, 100))
-              .trigger('resize.off-canvas');
-          }
-        },
-        'dialog:beforecreate': function (event, dialog, $element, settings) {
-          if ($element.is('#drupal-off-canvas')) {
-            $('body').addClass('js-tray-open');
-            // @see http://api.jqueryui.com/position/
-            settings.position = {
-              my: 'left top',
-              at: edge + ' top',
-              of: window
-            };
-            settings.dialogClass += ' ui-dialog-off-canvas';
-            // Applies initial height to dialog based on window height.
-            // See http://api.jqueryui.com/dialog for all dialog options.
-            settings.height = $(window).height();
-          }
-        },
-        'dialog:beforeclose': function (event, dialog, $element) {
-          if ($element.is('#drupal-off-canvas')) {
-            $('body').removeClass('js-tray-open');
-            // Remove all *.off-canvas events
-            $(document).off('.off-canvas');
-            $(window).off('.off-canvas');
-            $mainCanvasWrapper.css('padding-' + edge, 0);
-          }
+    /**
+     * Resets the size of the dialog.
+     *
+     * @param {jQuery.Event} event
+     *   The event triggered.
+     */
+    function resetSize(event) {
+      var offsets = displace.offsets;
+      var $element = event.data.$element;
+      var $widget = $element.dialog('widget');
+
+      var adjustedOptions = {
+        // @see http://api.jqueryui.com/position/
+        position: {
+          my: edge + ' top',
+          at: edge + ' top' + (offsets.top !== 0 ? '+' + offsets.top : ''),
+          of: window
         }
+      };
+
+      $widget.css({
+        position: 'fixed',
+        height: ($(window).height() - (offsets.top + offsets.bottom)) + 'px'
       });
+
+      $element
+          .dialog('option', adjustedOptions)
+          .trigger('dialogContentResize.off-canvas');
     }
+
+    /**
+     * Adjusts the dialog on resize.
+     *
+     * @param {jQuery.Event} event
+     *   The event triggered.
+     */
+    function handleDialogResize(event) {
+      var $element = event.data.$element;
+      var $widget = $element.dialog('widget');
+
+      var $offsets = $widget.find('> :not(#drupal-off-canvas, .ui-resizable-handle)');
+      var offset = 0;
+      var modalHeight;
+
+      // Let scroll element take all the height available.
+      $element.css({height: 'auto'});
+      modalHeight = $widget.height();
+      $offsets.each(function () { offset += $(this).outerHeight(); });
+
+      // Take internal padding into account.
+      var scrollOffset = $element.outerHeight() - $element.height();
+      $element.height(modalHeight - offset - scrollOffset);
+    }
+
+    /**
+     * Adjusts the body padding when the dialog is resized.
+     *
+     * @param {jQuery.Event} event
+     *   The event triggered.
+     */
+    function bodyPadding(event) {
+      if ($('body').outerWidth() < minDisplaceWidth) {
+        return;
+      }
+      var $element = event.data.$element;
+      var $widget = $element.dialog('widget');
+
+      var width = $widget.outerWidth();
+      var mainCanvasPadding = $mainCanvasWrapper.css('padding-' + edge);
+      if (width !== mainCanvasPadding) {
+        $mainCanvasWrapper.css('padding-' + edge, width + 'px');
+        $widget.attr('data-offset-' + edge, width);
+        displace();
+      }
+    }
+
+    return dialog;
   };
 
-})(jQuery, Drupal, Drupal.debounce, Drupal.displace);
+})(jQuery, Drupal, drupalSettings, Drupal.debounce, Drupal.displace);

--- a/core/modules/outside_in/js/off-canvas.js
+++ b/core/modules/outside_in/js/off-canvas.js
@@ -60,7 +60,7 @@
       // Applies initial height to dialog based on window height.
       // See http://api.jqueryui.com/dialog for all dialog options.
       settings.height = $(window).height();
-      $element.attr('data-dialog-render', 'offCanvasDialog');
+      $element.attr('data-dialog-renderer', 'offCanvasDialog');
     }
 
     function afterCreate(settings) {

--- a/core/modules/outside_in/src/Ajax/OpenOffCanvasDialogCommand.php
+++ b/core/modules/outside_in/src/Ajax/OpenOffCanvasDialogCommand.php
@@ -39,6 +39,7 @@ class OpenOffCanvasDialogCommand extends OpenDialogCommand {
     $this->dialogOptions['resizable'] = 'w';
     $this->dialogOptions['draggable'] = FALSE;
     $this->dialogOptions['drupalAutoButtons'] = FALSE;
+    $this->dialogOptions['drupalDialogType'] = 'offCanvasDialog';
     // @todo drupal.ajax.js does not respect drupalAutoButtons properly, pass an
     //   empty set of buttons until https://www.drupal.org/node/2793343 is in.
     $this->dialogOptions['buttons'] = [];

--- a/core/modules/outside_in/src/Ajax/OpenOffCanvasDialogCommand.php
+++ b/core/modules/outside_in/src/Ajax/OpenOffCanvasDialogCommand.php
@@ -39,7 +39,7 @@ class OpenOffCanvasDialogCommand extends OpenDialogCommand {
     $this->dialogOptions['resizable'] = 'w';
     $this->dialogOptions['draggable'] = FALSE;
     $this->dialogOptions['drupalAutoButtons'] = FALSE;
-    $this->dialogOptions['drupalDialogType'] = 'offCanvasDialog';
+    $this->dialogOptions['drupalDialogRenderer'] = 'offCanvasDialog';
     // @todo drupal.ajax.js does not respect drupalAutoButtons properly, pass an
     //   empty set of buttons until https://www.drupal.org/node/2793343 is in.
     $this->dialogOptions['buttons'] = [];


### PR DESCRIPTION
Basically this just creates a new Drupal.offCanvasDialog that is similar to Drupal.dialog but encapsulates all off the "off-canvas" functionality within it.

Drupal.offCanvasDialog is still uses jQuery dialog but it is not relying on Drupal.dialog to(though dialog.ajax.js still has this existing problem)

dialog.ajax.js is then altered to chose Drupal.offCanvasDialog or Drupal.dialog(or other dialog types in the future) by options set from the server-side.

Other implementations chose to incorporate both dialog types into Drupal.dialog if they choose.

This is as alternative to just making off-canvas use Drupal.dialog and just adding all functionality by reacting to dialog events. Which because of limitations on adding new methods to Drupal.dialog has to rely on jQuery dialog specific methods.

An example how bootstrap could work with this is https://github.com/tedbow/bootstrap-theme/commits/8.3-2830882-abstract_offcavnas
