### PR TITLE
Move block quick edit links out of Settings Tray

### DIFF
--- a/core/modules/block/block.links.contextual.yml
+++ b/core/modules/block/block.links.contextual.yml
@@ -1,3 +1,7 @@
+block_quick_edit:
+  title: 'Quick edit'
+  route_name: 'entity.block.off_canvas_form'
+  group: 'block'
 block_configure:
   title: 'Configure block'
   route_name: 'entity.block.edit_form'

--- a/core/modules/block/block.module
+++ b/core/modules/block/block.module
@@ -280,3 +280,31 @@ function block_configurable_language_delete(ConfigurableLanguageInterface $langu
     }
   }
 }
+
+/**
+ * Implements hook_contextual_links_view_alter().
+ *
+ * Change Configure Blocks into off_canvas links.
+ */
+function block_contextual_links_view_alter(&$element, $items) {
+  if (isset($element['#links']['block-quick-edit'])) {
+    // Place outside_in link first.
+    $quickedit_link = $element['#links']['block-quick-edit'];
+    unset($element['#links']['block-quick-edit']);
+    $element['#links'] = ['block-quick-edit' => $quickedit_link] + $element['#links'];
+
+    // @todo Move to block.links.contextual.yml in https://www.drupal.org/node/2892942
+    $element['#links']['block-quick-edit']['attributes'] = [
+      'class' => ['use-ajax'],
+      'data-dialog-type' => 'dialog',
+      'data-dialog-renderer' => 'off_canvas',
+      'data-outside-in-edit' => TRUE,
+    ];
+    // If this is content block change title to avoid duplicate "Quick Edit".
+    if (isset($element['#links']['block-contentblock-edit'])) {
+      $element['#links']['block-quick-edit']['title'] = t('Quick edit settings');
+    }
+
+    $element['#attached']['library'][] = 'core/drupal.dialog.off_canvas';
+  }
+}

--- a/core/modules/block/block.routing.yml
+++ b/core/modules/block/block.routing.yml
@@ -84,3 +84,12 @@ block.category_autocomplete:
     _controller: '\Drupal\block\Controller\CategoryAutocompleteController::autocomplete'
   requirements:
     _permission: 'administer blocks'
+
+entity.block.off_canvas_form:
+  path: '/admin/structure/block/manage/{block}/off-canvas'
+  defaults:
+    _entity_form: 'block.off_canvas'
+    _title_callback: '\Drupal\block\Form\BlockEntityOffCanvasForm::title'
+  requirements:
+    _permission: 'administer blocks'
+

--- a/core/modules/block/src/Entity/Block.php
+++ b/core/modules/block/src/Entity/Block.php
@@ -23,7 +23,8 @@ use Drupal\Core\Entity\EntityStorageInterface;
  *     "list_builder" = "Drupal\block\BlockListBuilder",
  *     "form" = {
  *       "default" = "Drupal\block\BlockForm",
- *       "delete" = "Drupal\block\Form\BlockDeleteForm"
+ *       "delete" = "Drupal\block\Form\BlockDeleteForm",
+ *       "off_canvas" = "Drupal\block\Form\BlockEntityOffCanvasForm",
  *     }
  *   },
  *   admin_permission = "administer blocks",
@@ -36,6 +37,7 @@ use Drupal\Core\Entity\EntityStorageInterface;
  *     "edit-form" = "/admin/structure/block/manage/{block}",
  *     "enable" = "/admin/structure/block/manage/{block}/enable",
  *     "disable" = "/admin/structure/block/manage/{block}/disable",
+ *     "off_canvas-form" = "/admin/structure/block/manage/{block}/off-canvas",
  *   },
  *   config_export = {
  *     "id",

--- a/core/modules/block/src/Form/BlockEntityOffCanvasForm.php
+++ b/core/modules/block/src/Form/BlockEntityOffCanvasForm.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\outside_in\Block;
+namespace Drupal\block\Form;
 
 use Drupal\block\BlockForm;
 use Drupal\block\BlockInterface;

--- a/core/modules/outside_in/outside_in.links.contextual.yml
+++ b/core/modules/outside_in/outside_in.links.contextual.yml
@@ -1,4 +1,0 @@
-outside_in.block_configure:
-  title: 'Quick edit'
-  route_name: 'entity.block.off_canvas_form'
-  group: 'block'

--- a/core/modules/outside_in/outside_in.module
+++ b/core/modules/outside_in/outside_in.module
@@ -7,9 +7,9 @@
 
 use Drupal\Core\Asset\AttachedAssetsInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
-use Drupal\outside_in\Block\BlockEntityOffCanvasForm;
-use Drupal\outside_in\Form\SystemBrandingOffCanvasForm;
-use Drupal\outside_in\Form\SystemMenuOffCanvasForm;
+use Drupal\block\Form\BlockEntityOffCanvasForm;
+use Drupal\system\Form\SystemBrandingOffCanvasForm;
+use Drupal\system\Form\SystemMenuOffCanvasForm;
 
 /**
  * Implements hook_help().
@@ -64,16 +64,6 @@ function outside_in_block_view_alter(array &$build) {
   $build['#contextual_links']['outside_in'] = [
     'route_parameters' => [],
   ];
-}
-
-/**
- * Implements hook_entity_type_build().
- */
-function outside_in_entity_type_build(array &$entity_types) {
-  /* @var $entity_types \Drupal\Core\Entity\EntityTypeInterface[] */
-  $entity_types['block']
-    ->setFormClass('off_canvas', BlockEntityOffCanvasForm::class)
-    ->setLinkTemplate('off_canvas-form', '/admin/structure/block/manage/{block}/off-canvas');
 }
 
 /**

--- a/core/modules/outside_in/outside_in.routing.yml
+++ b/core/modules/outside_in/outside_in.routing.yml
@@ -1,7 +1,0 @@
-entity.block.off_canvas_form:
-  path: '/admin/structure/block/manage/{block}/off-canvas'
-  defaults:
-    _entity_form: 'block.off_canvas'
-    _title_callback: '\Drupal\outside_in\Block\BlockEntityOffCanvasForm::title'
-  requirements:
-    _permission: 'administer blocks'

--- a/core/modules/system/src/Form/SystemBrandingOffCanvasForm.php
+++ b/core/modules/system/src/Form/SystemBrandingOffCanvasForm.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\outside_in\Form;
+namespace Drupal\system\Form;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;

--- a/core/modules/system/src/Form/SystemMenuOffCanvasForm.php
+++ b/core/modules/system/src/Form/SystemMenuOffCanvasForm.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\outside_in\Form;
+namespace Drupal\system\Form;
 
 use Drupal\Component\Plugin\PluginInspectionInterface;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;


### PR DESCRIPTION
Testing what it would take to move the "Quick Edit" links for all blocks into the Block module

This starts from https://www.drupal.org/node/2784443#comment-12177986

This would still a solution for this https://www.drupal.org/node/2764931#comment-12166654

Would also be simpler if https://www.drupal.org/node/2892942 was committed which was reverted
